### PR TITLE
Evitar Cadastros com CNPJ já existente

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -464,6 +464,27 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
             $this->errorJson(false);
         });
 
+        // Pré-validação: CNPJ já usado em PJ que o usuário não administra? (novo cadastro + alterar CNPJ)
+        $app->hook('POST(site.check-cnpj-org-conflict)', function () use ($app, $theme) {
+            $this->requireAuthentication();
+
+            $cnpjRaw = $this->data['cnpj'] ?? '';
+            $cnpjDigits = preg_replace('/\D/', '', (string) $cnpjRaw);
+            if (strlen($cnpjDigits) !== 14) {
+                $this->json(['conflict' => false]);
+
+                return;
+            }
+
+            $excludeAgentId = isset($this->data['excludeAgentId']) && $this->data['excludeAgentId'] !== ''
+                ? (int) $this->data['excludeAgentId']
+                : null;
+
+            $this->json([
+                'conflict' => $theme->isCnpjLinkedToOrganizationOutsideUserControl($app, $cnpjDigits, $excludeAgentId),
+            ]);
+        });
+
         // Termo de adesão
         $app->hook('GET(site.termoAdesao)', function() use($app) {
             $this->render('termo-adesao', []);
@@ -2959,6 +2980,56 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
         
         $app->sendMailMessage($app->createMailMessage($mail));
 
+    }
+
+    /**
+     * IDs de agentes que já têm esse CNPJ em agent_meta (chaves cnpj ou documento), sem depender da máscara.
+     *
+     * @return list<int>
+     */
+    public function getDistinctAgentIdsWithCnpjInMetadata(App $app, string $cnpjDigits): array
+    {
+        $conn = $app->em->getConnection();
+        $sql = <<<'SQL'
+            SELECT DISTINCT object_id
+            FROM agent_meta
+            WHERE key IN ('cnpj', 'documento')
+              AND regexp_replace(COALESCE(value, ''), '[^0-9]', '', 'g') = :digits
+            SQL;
+
+        $rows = $conn->fetchFirstColumn($sql, ['digits' => $cnpjDigits]);
+
+        return array_map(static fn ($id): int => (int) $id, $rows);
+    }
+
+    /**
+     * Retorna true se existir algum agente com esse CNPJ que o usuário atual não controla (@control).
+     * Novo cadastro e alteração de CNPJ usam a mesma regra: vários PJs "meus" com o mesmo número não bloqueiam.
+     * Em alteração, passamos excludeAgentId para ignorar o coletivo da inscrição e avaliar só o restante.
+     */
+    public function isCnpjLinkedToOrganizationOutsideUserControl(App $app, string $cnpjDigits, ?int $excludeAgentId): bool
+    {
+        $agentIds = $this->getDistinctAgentIdsWithCnpjInMetadata($app, $cnpjDigits);
+
+        if ($excludeAgentId !== null) {
+            $agentIds = array_values(array_filter(
+                $agentIds,
+                static fn (int $id): bool => $id !== $excludeAgentId
+            ));
+        }
+
+        $user = $app->user;
+        foreach ($agentIds as $agentId) {
+            $agent = $app->repo('Agent')->find($agentId);
+            if (!$agent instanceof Agent) {
+                continue;
+            }
+            if (!$agent->canUser('@control', $user)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function sendMailRegistrationPnabDenied(Registration $registration) {

--- a/Theme.php
+++ b/Theme.php
@@ -464,7 +464,9 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
             $this->errorJson(false);
         });
 
-        // Pré-validação: CNPJ já usado em PJ que o usuário não administra? (novo cadastro + alterar CNPJ)
+        // Pré-validação CNPJ: inscrições RCV (coletivo + meta). Alterar CNPJ: excludeAgentId + categoria pelo coletivo.
+        // Novo cadastro: opcional subscriptionType ponto-entidade|pontao (bloqueia só essa modalidade se já existir).
+        // Sem subscriptionType: só bloqueia “lotado” (já tem Ponto e Pontão) ou 2+ Pontões — não bloqueia só por vários Pontos (ex.: permite seguir para Pontão no curl/UI legada).
         $app->hook('POST(site.check-cnpj-org-conflict)', function () use ($app, $theme) {
             $this->requireAuthentication();
 
@@ -480,9 +482,56 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
                 ? (int) $this->data['excludeAgentId']
                 : null;
 
-            $this->json([
-                'conflict' => $theme->isCnpjLinkedToOrganizationOutsideUserControl($app, $cnpjDigits, $excludeAgentId),
-            ]);
+            $categoriesMap = $app->config['rcv.categoriesMap'] ?? [];
+            $pontoLabel = $categoriesMap['ponto-entidade'] ?? '';
+            $pontaoLabel = $categoriesMap['pontao'] ?? '';
+
+            if ($excludeAgentId !== null) {
+                $subscriptionKey = $theme->getRcvSubscriptionTypeKeyByColetivoAgentId($app, $excludeAgentId);
+                $categoryLabel = null;
+                if ($subscriptionKey === 'ponto-entidade') {
+                    $categoryLabel = $pontoLabel;
+                } elseif ($subscriptionKey === 'pontao') {
+                    $categoryLabel = $pontaoLabel;
+                }
+
+                if ($categoryLabel === null || $categoryLabel === '') {
+                    $this->json(['conflict' => false]);
+
+                    return;
+                }
+
+                $conflict = $theme->countRcvRegistrationsWithColetivoCnpjAndCategory(
+                    $app,
+                    $cnpjDigits,
+                    $categoryLabel,
+                    $excludeAgentId
+                ) > 0;
+            } else {
+                $nPonto = $theme->countRcvRegistrationsWithColetivoCnpjAndCategory(
+                    $app,
+                    $cnpjDigits,
+                    $pontoLabel,
+                    null
+                );
+                $nPontao = $theme->countRcvRegistrationsWithColetivoCnpjAndCategory(
+                    $app,
+                    $cnpjDigits,
+                    $pontaoLabel,
+                    null
+                );
+
+                $subscriptionKey = $this->data['subscriptionType'] ?? null;
+                if ($subscriptionKey === 'ponto-entidade') {
+                    $conflict = $nPonto >= 1;
+                } elseif ($subscriptionKey === 'pontao') {
+                    $conflict = $nPontao >= 1;
+                } else {
+                    $conflict = $nPontao >= 2 || ($nPonto >= 1 && $nPontao >= 1);
+                }
+            }
+
+            $this->json(['conflict' => $conflict]);
         });
 
         // Termo de adesão
@@ -2983,53 +3032,94 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
     }
 
     /**
-     * IDs de agentes que já têm esse CNPJ em agent_meta (chaves cnpj ou documento), sem depender da máscara.
-     *
-     * @return list<int>
+     * Chave ponto-entidade|pontao conforme a inscrição RCV ligada ao agente coletivo (ex.: fluxo alterar CNPJ com excludeAgentId).
      */
-    public function getDistinctAgentIdsWithCnpjInMetadata(App $app, string $cnpjDigits): array
+    public function getRcvSubscriptionTypeKeyByColetivoAgentId(App $app, int $coletivoAgentId): ?string
     {
+        if ($coletivoAgentId <= 0) {
+            return null;
+        }
+
+        $opportunityId = (int) $app->config['rcv.opportunityId'];
+        $categoriesMap = $app->config['rcv.categoriesMap'] ?? [];
         $conn = $app->em->getConnection();
-        $sql = <<<'SQL'
-            SELECT DISTINCT object_id
-            FROM agent_meta
-            WHERE key IN ('cnpj', 'documento')
-              AND regexp_replace(COALESCE(value, ''), '[^0-9]', '', 'g') = :digits
-            SQL;
+        $registrationObjectType = Registration::class;
 
-        $rows = $conn->fetchFirstColumn($sql, ['digits' => $cnpjDigits]);
+        $sql = "
+            SELECT r.category
+            FROM registration r
+            INNER JOIN agent_relation ar ON ar.object_id = r.id
+                AND ar.object_type = '{$registrationObjectType}'
+                AND ar.type = 'coletivo'
+            WHERE ar.agent_id = :agentId
+              AND r.opportunity_id = :oppId
+              AND r.status != :trash
+            LIMIT 1
+        ";
 
-        return array_map(static fn ($id): int => (int) $id, $rows);
+        $category = $conn->fetchOne($sql, [
+            'agentId' => $coletivoAgentId,
+            'oppId' => $opportunityId,
+            'trash' => Registration::STATUS_TRASH,
+        ]);
+
+        if (!is_string($category) || $category === '') {
+            return null;
+        }
+
+        if ($category === ($categoriesMap['ponto-entidade'] ?? '')) {
+            return 'ponto-entidade';
+        }
+        if ($category === ($categoriesMap['pontao'] ?? '')) {
+            return 'pontao';
+        }
+
+        return null;
     }
 
     /**
-     * Retorna true se existir algum agente com esse CNPJ que o usuário atual não controla (@control).
-     * Novo cadastro e alteração de CNPJ usam a mesma regra: vários PJs "meus" com o mesmo número não bloqueiam.
-     * Em alteração, passamos excludeAgentId para ignorar o coletivo da inscrição e avaliar só o restante.
+     * Inscrições na oportunidade Cultura Viva com agente coletivo contendo o CNPJ e a categoria informados (Ponto entidade ou Pontão).
      */
-    public function isCnpjLinkedToOrganizationOutsideUserControl(App $app, string $cnpjDigits, ?int $excludeAgentId): bool
-    {
-        $agentIds = $this->getDistinctAgentIdsWithCnpjInMetadata($app, $cnpjDigits);
+    public function countRcvRegistrationsWithColetivoCnpjAndCategory(
+        App $app,
+        string $cnpjDigits,
+        string $categoryLabel,
+        ?int $excludeColetivoAgentId
+    ): int {
+        $opportunityId = (int) $app->config['rcv.opportunityId'];
+        $conn = $app->em->getConnection();
+        $registrationObjectType = Registration::class;
 
-        if ($excludeAgentId !== null) {
-            $agentIds = array_values(array_filter(
-                $agentIds,
-                static fn (int $id): bool => $id !== $excludeAgentId
-            ));
+        $params = [
+            'digits' => $cnpjDigits,
+            'category' => $categoryLabel,
+            'oppId' => $opportunityId,
+            'trash' => Registration::STATUS_TRASH,
+        ];
+        $excludeSql = '';
+        if ($excludeColetivoAgentId !== null) {
+            $excludeSql = ' AND ar.agent_id <> :excludeAgentId';
+            $params['excludeAgentId'] = $excludeColetivoAgentId;
         }
 
-        $user = $app->user;
-        foreach ($agentIds as $agentId) {
-            $agent = $app->repo('Agent')->find($agentId);
-            if (!$agent instanceof Agent) {
-                continue;
-            }
-            if (!$agent->canUser('@control', $user)) {
-                return true;
-            }
-        }
+        $sql = "
+            SELECT COUNT(DISTINCT r.id)
+            FROM registration r
+            INNER JOIN agent_relation ar ON ar.object_id = r.id
+                AND ar.object_type = '{$registrationObjectType}'
+                AND ar.type = 'coletivo'
+            INNER JOIN agent_meta am ON am.object_id = ar.agent_id
+                AND am.key IN ('cnpj', 'documento')
+                AND regexp_replace(COALESCE(am.value, ''), '[^0-9]', '', 'g') = :digits
+            WHERE r.opportunity_id = :oppId
+              AND r.category = :category
+              AND r.status != :trash
+            {$excludeSql}
+        ";
 
-        return false;
+        $count = $conn->fetchFirstColumn($sql, $params);
+
+        return (int) ($count[0] ?? 0);
     }
 
     public function sendMailRegistrationPnabDenied(Registration $registration) {

--- a/assets-src/sass/2.components/_point-subscription.scss
+++ b/assets-src/sass/2.components/_point-subscription.scss
@@ -159,3 +159,9 @@
         }
     }
 }
+
+// E-mail de suporte no modal de CNPJ: mesmo padrão do rodapé (Contato por e-mail)
+.rcv-cnpj-conflict-modal__support-mail {
+    color: $agents-500;
+    font-weight: $font-weight-regular;
+}

--- a/components/rcv-point-subscription/script.js
+++ b/components/rcv-point-subscription/script.js
@@ -51,7 +51,6 @@ app.component('rcv-point-subscription' , {
             invalidPrincipalAgent: false,
             agentType: $MAPAS.user.profile?.type?.id,
             invalidAgentType: this.agentType === 2,
-            /** Exibe aviso quando o CNPJ está em uso por organização de outro titular */
             hasCnpjExternalOrgConflict: false,
         };
     },
@@ -208,7 +207,7 @@ app.component('rcv-point-subscription' , {
             }
         },
 
-        // Antes da Receita: só barra se o CNPJ estiver em PJ que o usuário não administra
+        // Antes da Receita: conflito de CNPJ conforme regra no endpoint (inscrições RCV)
         async verifyCNPJ() {
             let returnApi = false;
 
@@ -220,7 +219,11 @@ app.component('rcv-point-subscription' , {
             this.hasCnpjExternalOrgConflict = false;
 
             try {
-                const checkRes = await api.POST(checkConflictUrl, { cnpj: this.cnpj });
+                const checkPayload = { cnpj: this.cnpj };
+                if (this.subscriptionType === 'ponto-entidade' || this.subscriptionType === 'pontao') {
+                    checkPayload.subscriptionType = this.subscriptionType;
+                }
+                const checkRes = await api.POST(checkConflictUrl, checkPayload);
                 const checkData = await checkRes.json();
                 if (checkData.conflict) {
                     this.hasCnpjExternalOrgConflict = true;

--- a/components/rcv-point-subscription/script.js
+++ b/components/rcv-point-subscription/script.js
@@ -51,6 +51,8 @@ app.component('rcv-point-subscription' , {
             invalidPrincipalAgent: false,
             agentType: $MAPAS.user.profile?.type?.id,
             invalidAgentType: this.agentType === 2,
+            /** Exibe aviso quando o CNPJ está em uso por organização de outro titular */
+            hasCnpjExternalOrgConflict: false,
         };
     },
 
@@ -80,6 +82,9 @@ app.component('rcv-point-subscription' , {
 
             if (this.loggedOut) {
                 return this.text('Ops! Você precisa fazer login para acessar o Cadastro');
+
+            } else if (this.hasCnpjExternalOrgConflict) {
+                return this.text('CNPJ já vinculado a outra organização');
 
             } else if(!error && this.loading) {
                 return this.text('Buscando por suas organizações');
@@ -180,6 +185,7 @@ app.component('rcv-point-subscription' , {
             this.isCertificated = false;
             this.invalidPrincipalAgent = false;
             this.invalidAgentType = false;
+            this.hasCnpjExternalOrgConflict = false;
 
             this.modalLoggedOut();
         },
@@ -202,15 +208,29 @@ app.component('rcv-point-subscription' , {
             }
         },
 
-        verifyCNPJ() {
+        // Antes da Receita: só barra se o CNPJ estiver em PJ que o usuário não administra
+        async verifyCNPJ() {
             let returnApi = false;
 
-            let url = Utils.createUrl('site/valida-cnpj', '');
-            let api = new API();
-            let data = { cnpj: this.cnpj };
-            
+            const checkConflictUrl = Utils.createUrl('site/check-cnpj-org-conflict', '');
+            const validateCnpjUrl = Utils.createUrl('site/valida-cnpj', '');
+            const api = new API();
+
             this.isLoading = true;
-            api.POST(url, data).then(res => res.json()).then(data => {
+            this.hasCnpjExternalOrgConflict = false;
+
+            try {
+                const checkRes = await api.POST(checkConflictUrl, { cnpj: this.cnpj });
+                const checkData = await checkRes.json();
+                if (checkData.conflict) {
+                    this.hasCnpjExternalOrgConflict = true;
+                    this.isLoading = false;
+
+                    return;
+                }
+
+                const res = await api.POST(validateCnpjUrl, { cnpj: this.cnpj });
+                const data = await res.json();
                 this.isLoading = false;
                 returnApi = data?.data ?? data;
                 this.hasError = data?.error || false;
@@ -240,7 +260,10 @@ app.component('rcv-point-subscription' , {
                     this.invalidCNPJ = returnApi;
                     this.rfData = returnApi;
                 }
-            })
+            } catch (error) {
+                console.error(error);
+                this.isLoading = false;
+            }
         },
 
         async createOrganization(returnApi = false) {

--- a/components/rcv-point-subscription/template.php
+++ b/components/rcv-point-subscription/template.php
@@ -40,7 +40,13 @@ $this->import('
                     </template>
 
                     <!-- logado -->
-                    <template v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ" #default>
+                    <template v-if="global.auth.isLoggedIn && hasCnpjExternalOrgConflict && !nextStep && !verifiedCNPJ" #default>
+                        <div class="rcv-point-subscription__subscription__card__modal">
+                            <p><?= i::__('Este CNPJ já está vinculado a outra organização.<br> Se precisar de ajuda para regularizar o cadastro, entre em contato com <a href="mailto:suporte.culturaviva@cultura.gov.br" class="rcv-cnpj-conflict-modal__support-mail"><strong>suporte.culturaviva@cultura.gov.br</strong></a>.') ?></p>
+                        </div>
+                    </template>
+
+                    <template v-else-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ" #default>
                         <div class="field">
                             <div class="field">
                                 <label><?= i::__("CNPJ da instituição") ?>
@@ -110,7 +116,12 @@ $this->import('
                             <button v-if="global.auth.isLoggedIn && errorSituacaoCadastral && !isLoading" class="button button--icon button--md rcv-point-subscription__subscription__card__verify" @click="modal.close()"> <?= i::__('Ok') ?></button>
                             <button v-if="global.auth.isLoggedIn && nextStep && verifiedCNPJ && !naturezaJuridicaInvalida && !isLoading" class="button button--icon button--md rcv-point-subscription__subscription__card__verify" :class="{'disabled' : hasError}" @click="confirmAndSubscribe()"><?= i::__('Cadastrar') ?></button>
                         </div>
-                        <div v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType" class="rcv-point-subscription__subscription__card__buttons">
+                        <div v-if="global.auth.isLoggedIn && hasCnpjExternalOrgConflict && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType" class="rcv-point-subscription__subscription__card__buttons">
+                            <button type="button" class="button button--icon button--md rcv-point-subscription__subscription__card__verify" @click="hasCnpjExternalOrgConflict = false">
+                                <?= i::__('Ok') ?>
+                            </button>
+                        </div>
+                        <div v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType && !hasCnpjExternalOrgConflict" class="rcv-point-subscription__subscription__card__buttons">
                             <mc-loading v-if="isLoading" :condition="isLoading" :entity="entity"></mc-loading>
                             <button v-if="!isLoading" @click="verifyCNPJ" class="button button--icon button--md rcv-point-subscription__subscription__card__verify"><?= i::__('Verificar CNPJ') ?></button>
                         </div>
@@ -248,7 +259,13 @@ $this->import('
                     </template>
 
                     <!-- logado -->
-                    <template v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ" #default>
+                    <template v-if="global.auth.isLoggedIn && hasCnpjExternalOrgConflict && !nextStep && !verifiedCNPJ" #default>
+                        <div class="rcv-point-subscription__subscription__card__modal">
+                            <p><?= i::__('Este CNPJ já está vinculado a outra organização.<br> Se precisar de ajuda para regularizar o cadastro, entre em contato com <a href="mailto:suporte.culturaviva@cultura.gov.br" class="rcv-cnpj-conflict-modal__support-mail"><strong>suporte.culturaviva@cultura.gov.br</strong></a>.') ?></p>
+                        </div>
+                    </template>
+
+                    <template v-else-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ" #default>
                         <div class="field">
                             <div class="field">
                                 <label><?= i::__("CNPJ da instituição") ?>
@@ -327,7 +344,12 @@ $this->import('
                             </button>
                         </div>
 
-                        <div v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType" class="rcv-point-subscription__subscription__card__buttons">
+                        <div v-if="global.auth.isLoggedIn && hasCnpjExternalOrgConflict && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType" class="rcv-point-subscription__subscription__card__buttons">
+                            <button type="button" class="button button--icon rcv-point-subscription__subscription__card__verify" @click="hasCnpjExternalOrgConflict = false">
+                                <?= i::__('Ok') ?>
+                            </button>
+                        </div>
+                        <div v-if="global.auth.isLoggedIn && !nextStep && !verifiedCNPJ && !invalidPrincipalAgent && !invalidAgentType && !hasCnpjExternalOrgConflict" class="rcv-point-subscription__subscription__card__buttons">
                             <mc-loading v-if="isLoading" :condition="isLoading" :entity="entity"></mc-loading>
                             <button v-if="!isLoading" @click="verifyCNPJ" class="button button--icon rcv-point-subscription__subscription__card__verify"><?= i::__('Verificar CNPJ') ?></button>
                         </div>

--- a/components/rcv-point-subscription/texts.php
+++ b/components/rcv-point-subscription/texts.php
@@ -13,4 +13,6 @@ return [
     'Cadastre uma organização ou selecione uma já existente' => i::__('Cadastre uma organização ou selecione uma já existente'),
     'Ops! Identificamos uma inconsistência nos seus dados' => i::__('Ops! Identificamos uma inconsistência nos seus dados'),
     'Não é possível continuar o cadastro' => i::__('Não é possível continuar o cadastro'),
+    'CNPJ já vinculado a outra organização' => i::__('CNPJ já vinculado a outra organização'),
+    'Este CNPJ já está vinculado a outra organização.<br> Se precisar de ajuda para regularizar o cadastro, entre em contato com <a href="mailto:suporte.culturaviva@cultura.gov.br" class="rcv-cnpj-conflict-modal__support-mail"><strong>suporte.culturaviva@cultura.gov.br</strong></a>.' => i::__('Este CNPJ já está vinculado a outra organização.<br> Se precisar de ajuda para regularizar o cadastro, entre em contato com <a href="mailto:suporte.culturaviva@cultura.gov.br" class="rcv-cnpj-conflict-modal__support-mail"><strong>suporte.culturaviva@cultura.gov.br</strong></a>.'),
 ];

--- a/components/rcv-registration-update-cnpj/script.js
+++ b/components/rcv-registration-update-cnpj/script.js
@@ -48,6 +48,8 @@ app.component('rcv-registration-update-cnpj', {
             apiInfo: null,
             opportunity: $MAPAS.config.rcvRegistrationUpdateCnpj.opportunity,
             status: $MAPAS.config.rcvRegistrationUpdateCnpj.status,
+            /** Mesma regra do novo cadastro: bloqueia só se o CNPJ estiver em PJ de terceiro */
+            hasCnpjExternalOrgConflict: false,
         };
     },
 
@@ -77,6 +79,9 @@ app.component('rcv-registration-update-cnpj', {
             const global = useGlobalState();
 
             if (global.auth.isLoggedIn) {
+                if (this.hasCnpjExternalOrgConflict && this.step === 'get-cnpj') {
+                    return 'CNPJ já vinculado a outra organização';
+                }
                 switch (this.step) {
                     case 'get-cnpj':
                         return 'Informe o novo CNPJ da organização';
@@ -135,25 +140,46 @@ app.component('rcv-registration-update-cnpj', {
             this.invalidCNPJ = false;
             this.situacaoCadastralError = '';
             this.apiInfo = null;
+            this.hasCnpjExternalOrgConflict = false;
         },
 
         saveRegistrationInfo(registration) {
             this.registrationInfo = registration;
         },
 
-        verifyCNPJ() {
+        async verifyCNPJ() {
             let returnApi = false;
 
-            let url = Utils.createUrl('site/valida-cnpj', '');
-            let api = new API();
-            let data = { cnpj: this.cnpj };
-            
+            const checkConflictUrl = Utils.createUrl('site/check-cnpj-org-conflict', '');
+            const validateCnpjUrl = Utils.createUrl('site/valida-cnpj', '');
+            const api = new API();
+
+            const excludeAgentId = this.registrationInfo?.relatedAgents?.coletivo?.[0]?.id;
+
             this.disableButton = true;
-            api.POST(url, data).then(res => res.json()).then(data => {
+            this.hasCnpjExternalOrgConflict = false;
+
+            try {
+                const payload = { cnpj: this.cnpj };
+                if (excludeAgentId) {
+                    payload.excludeAgentId = excludeAgentId;
+                }
+
+                const checkRes = await api.POST(checkConflictUrl, payload);
+                const checkData = await checkRes.json();
+                if (checkData.conflict) {
+                    this.hasCnpjExternalOrgConflict = true;
+                    this.disableButton = false;
+
+                    return;
+                }
+
+                const res = await api.POST(validateCnpjUrl, { cnpj: this.cnpj });
+                const data = await res.json();
                 returnApi = data?.data ?? data;
                 this.hasError = data?.error || false;
-                this.disableButton = true;
-                
+                this.disableButton = false;
+
                 if(!returnApi) {
                     this.invalidCNPJ = true;
                 } else if(returnApi == 'natureza-juridica-invalida') {
@@ -166,7 +192,10 @@ app.component('rcv-registration-update-cnpj', {
                     this.situacaoCadastralError = returnApi;
                     this.changeStep('situacao-cadastral');
                 }
-            })
+            } catch (error) {
+                console.error(error);
+                this.disableButton = false;
+            }
         },
 
         updateCNPJ(modal) {

--- a/components/rcv-registration-update-cnpj/script.js
+++ b/components/rcv-registration-update-cnpj/script.js
@@ -48,7 +48,6 @@ app.component('rcv-registration-update-cnpj', {
             apiInfo: null,
             opportunity: $MAPAS.config.rcvRegistrationUpdateCnpj.opportunity,
             status: $MAPAS.config.rcvRegistrationUpdateCnpj.status,
-            /** Mesma regra do novo cadastro: bloqueia só se o CNPJ estiver em PJ de terceiro */
             hasCnpjExternalOrgConflict: false,
         };
     },

--- a/components/rcv-registration-update-cnpj/template.php
+++ b/components/rcv-registration-update-cnpj/template.php
@@ -58,7 +58,11 @@ $route = $app->createUrl('auth');
             </mc-entities>
         </div>
 
-        <div v-if="step=='get-cnpj'" class="rcv-registration-update__modal-content">
+        <div v-if="step=='get-cnpj' && hasCnpjExternalOrgConflict" class="rcv-registration-update__modal-content">
+            <p><?= i::__('Este CNPJ já está vinculado a outra organização.<br> Se precisar de ajuda para regularizar o cadastro, entre em contato com <a href="mailto:suporte.culturaviva@cultura.gov.br" class="rcv-cnpj-conflict-modal__support-mail"><strong>suporte.culturaviva@cultura.gov.br</strong></a>.') ?></p>
+        </div>
+
+        <div v-else-if="step=='get-cnpj'" class="rcv-registration-update__modal-content">
             <div class="field">
                 <input type="text" v-maska data-maska="##.###.###/####-##" v-model="cnpj"/>
                 <span v-if="invalidCNPJ" class="field__error"><?= i::__('Ops! Não foi possível fazer a consulta. Tente novamente mais tarde') ?></span>
@@ -104,7 +108,11 @@ $route = $app->createUrl('auth');
             <?= i::__('Confirmar') ?>
         </button>
 
-        <button v-if="global.auth.isLoggedIn && step=='get-cnpj'" class="button button--primary" :class="[{'disabled' : disableButton}]" @click="verifyCNPJ()">
+        <button v-if="global.auth.isLoggedIn && step=='get-cnpj' && hasCnpjExternalOrgConflict" type="button" class="button button--icon button--md rcv-point-subscription__subscription__card__verify" @click="hasCnpjExternalOrgConflict = false">
+            <?= i::__('Ok') ?>
+        </button>
+
+        <button v-if="global.auth.isLoggedIn && step=='get-cnpj' && !hasCnpjExternalOrgConflict" class="button button--icon button--md rcv-point-subscription__subscription__card__verify" :class="[{'disabled' : disableButton}]" @click="verifyCNPJ()">
             <?= i::__('Verificar CNPJ') ?>
         </button>
 


### PR DESCRIPTION
## Cenário

O problema que queremos evitar é **reutilizar um CNPJ que já pertence, na plataforma, a uma organização administrada por outra pessoa** — situação que exige tratamento pelo suporte, não uma nova consulta automática.

## Objetivo

Evitar chamar o Barramento de Serviços quando o CNPJ informado já está associado, no `agent_meta`, a **organização (PJ) que o usuário logado não administra** (`@control`). Se o CNPJ existir apenas em PJs que o próprio usuário controla, o fluxo segue normalmente.

<img width="783" height="346" alt="image" src="https://github.com/user-attachments/assets/eb62eca7-29d5-43a6-9e95-f1c9c83db6c8" />

## Cenários principais

| Situação | Comportamento esperado |
|----------|-------------------------|
| CNPJ não existe em `agent_meta` | Sem conflito → segue para o Barramento de Serviços. |
| CNPJ só em agentes que o usuário **controla** | Sem conflito → não bloqueia. |
| CNPJ em agente que o usuário **não** controla | Conflito → modal; não chama o Barramento de Serviços.|
| Alteração de CNPJ com o mesmo número ainda no coletivo atual | Coletivo excluído da análise via `excludeAgentId`. |
