### PR TITLE
O.S 9383 - Correção de exibição da localização para certificado internacional

### DIFF
--- a/views/seal/certificado-pontao.php
+++ b/views/seal/certificado-pontao.php
@@ -25,7 +25,10 @@ $estado = $isOutsideBrazil ? $pontao->En_EstadoPontaPontao : $pontao->En_Estado;
 $pais = $pais == 'BR' ? 'Brasil' : $pais;
 
 if ($isOutsideBrazil && $pais) {
-    $address = "<p>{$pais}</p>";
+    $address = "
+        <p>{$pais}</p>
+        <p>{$municipio}</p>
+    ";
 } elseif ($pais && $municipio && $estado) {
     $address = "
         <p>{$pais}</p>

--- a/views/seal/certificado-pontao.php
+++ b/views/seal/certificado-pontao.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @var MapasCulturais\App $app
  * @var MapasCulturais\Entities\SealRelation $relation
  */
 use MapasCulturais\i;
@@ -11,20 +12,25 @@ $pontao = $relation->owner;
 $creationDate = $relation->createTimestamp->format('d/m/Y');
 $updateDate = null;
 
-if($ponto->rcv_last_update_timestamp) {
-    $last_update = new \DateTime($ponto->rcv_last_update_timestamp);
+if($pontao->rcv_last_update_timestamp) {
+    $last_update = new \DateTime($pontao->rcv_last_update_timestamp);
     $updateDate = $last_update->format('d/m/Y');
 }
 
 $address = "";
-$pais = $pontao->En_Pais ?: $app->config['app.defaultCountry'];
+$isOutsideBrazil = $pontao->rcv_org_brasil === 'Não';
+$pais = $isOutsideBrazil ? $pontao->paisPontaPontao : ($pontao->En_Pais ?: $app->config['app.defaultCountry']);
+$municipio = $isOutsideBrazil ? $pontao->En_MunicipioPontaPontao : $pontao->En_Municipio;
+$estado = $isOutsideBrazil ? $pontao->En_EstadoPontaPontao : $pontao->En_Estado;
 $pais = $pais == 'BR' ? 'Brasil' : $pais;
 
-if ($pontao->En_Pais && $pontao->En_Municipio && $pontao->En_Estado) {
+if ($isOutsideBrazil && $pais) {
+    $address = "<p>{$pais}</p>";
+} elseif ($pais && $municipio && $estado) {
     $address = "
         <p>{$pais}</p>
-        <p>{$pontao->En_Municipio}</p>
-        <p>{$pontao->En_Estado}</p>
+        <p>{$municipio}</p>
+        <p>{$estado}</p>
     ";
 } else {
     $address = "<p>".i::__('Não se aplica')."</p>";

--- a/views/seal/certificado-ponto.php
+++ b/views/seal/certificado-ponto.php
@@ -26,7 +26,10 @@ $estado = $isOutsideBrazil ? $ponto->En_EstadoPontaPontao : $ponto->En_Estado;
 $pais = $pais == 'BR' ? 'Brasil' : $pais;
 
 if ($isOutsideBrazil && $pais) {
-    $address = "<p>{$pais}</p>";
+    $address = "
+        <p>{$pais}</p>
+        <p>{$municipio}</p>
+    ";
 } elseif ($pais && $municipio && $estado) {
     $address = "
         <p>{$pais}</p>

--- a/views/seal/certificado-ponto.php
+++ b/views/seal/certificado-ponto.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ * @var MapasCulturais\App $app
  * @var MapasCulturais\Entities\SealRelation $relation
  */
 
@@ -18,14 +19,19 @@ if($ponto->rcv_last_update_timestamp) {
 }
 
 $address = "";
-$pais = $ponto->En_Pais ?: $app->config['app.defaultCountry'];
+$isOutsideBrazil = $ponto->rcv_org_brasil === 'Não';
+$pais = $isOutsideBrazil ? $ponto->paisPontaPontao : ($ponto->En_Pais ?: $app->config['app.defaultCountry']);
+$municipio = $isOutsideBrazil ? $ponto->En_MunicipioPontaPontao : $ponto->En_Municipio;
+$estado = $isOutsideBrazil ? $ponto->En_EstadoPontaPontao : $ponto->En_Estado;
 $pais = $pais == 'BR' ? 'Brasil' : $pais;
 
-if ($ponto->En_Pais && $ponto->En_Municipio && $ponto->En_Estado) {
+if ($isOutsideBrazil && $pais) {
+    $address = "<p>{$pais}</p>";
+} elseif ($pais && $municipio && $estado) {
     $address = "
         <p>{$pais}</p>
-        <p>{$ponto->En_Municipio}</p>
-        <p>{$ponto->En_Estado}</p>
+        <p>{$municipio}</p>
+        <p>{$estado}</p>
     ";
 } else {
     $address = "<p>".i::__('Não se aplica')."</p>";


### PR DESCRIPTION
**Problema identificado**: O certificado buscava a localização nos campos padrão do agente (**En_Pais, En_Municipio, En_Estado**). Porém, para inscrições internacionais, o formulário salva o país no campo específico paisPontaPontao. Com isso, mesmo quando o país estava preenchido corretamente no cadastro, o certificado exibia Não se aplica.

**Solução implementada**: Foi ajustada a lógica dos certificados para identificar quando a organização não está sediada no Brasil. Nesses casos, o certificado passa a exibir o país a partir do campo correto (**paisPontaPontao**). Para organizações sediadas no Brasil, o comportamento anterior foi mantido.