### PR TITLE
fix(init): exibe inscrições aprovadas para usuários com convite pendente

### DIFF
--- a/Theme.php
+++ b/Theme.php
@@ -667,7 +667,7 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
                 $agent_relations = $agent->agentRelations;
 
                 foreach($agent_relations as $relation) {
-                    if($relation->agent->id == $user->profile->id && $relation->status == AgentRelation::STATUS_ENABLED) {
+                    if($relation->agent->id == $user->profile->id && in_array($relation->status, [AgentRelation::STATUS_ENABLED, -5])) {
                         $enable_editable_fields = true;
                         break;
                     }
@@ -676,6 +676,29 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
 
             if(($_SESSION["{$this}:editableFields"] ?? false) || $enable_editable_fields) {
                 $canUser = true;
+            }
+        });
+
+        // Permite acesso à inscrição RCV para usuários com relação pendente (convite não aceito)
+        $app->hook('entity(Registration).canUser(<<view|@control|modify>>)', function($user, &$canUser) use($app) {
+            if ($canUser || $user->is('admin') || $this->opportunity->id != $app->config['rcv.opportunityId']) {
+                return;
+            }
+
+            $coletivo = $this->relatedAgents['coletivo'][0] ?? null;
+            if ($coletivo) {
+                $hasRelation = $app->em->getConnection()->fetchOne("
+                    SELECT 1 FROM agent_relation 
+                    WHERE object_id = :collectiveId 
+                      AND object_type = 'MapasCulturais\\Entities\\Agent' 
+                      AND agent_id = :agentId 
+                      AND status IN (1, -5)
+                    LIMIT 1
+                ", ['collectiveId' => $coletivo->id, 'agentId' => $user->profile->id]);
+
+                if ($hasRelation) {
+                    $canUser = true;
+                }
             }
         });
 

--- a/components/rcv-registration-update/init.php
+++ b/components/rcv-registration-update/init.php
@@ -10,15 +10,57 @@ use MapasCulturais\Entities\Agent;
 use MapasCulturais\Entities\Registration;
 
 if (!$app->user->is('admin')) {
+    $app->disableAccessControl();
 
-    $query = new ApiQuery(Registration::class, [
-        '@permissions' => '@control', 
-        '@select' => 'id,number,category,relatedAgents,owner.{name}', 
-        '@order' => 'id ASC', 
-        'opportunity' => API::EQ($app->config['rcv.opportunityId']), 
-        'status' => API::EQ(Registration::STATUS_APPROVED)
+    $conn = $app->em->getConnection();
+    $agentId = $app->user->profile->id;
+    $opportunity = (int) $app->config['rcv.opportunityId'];
+
+    $registrationObjectType = str_replace('\\', '\\\\', Registration::class);
+
+     $ids = $conn->fetchFirstColumn("
+        SELECT DISTINCT r.id
+        FROM registration r
+        INNER JOIN agent owner_agent
+            ON owner_agent.id = r.owner
+        WHERE r.opportunity_id = :oppId
+          AND r.status         = :approved
+          AND (
+              owner_agent.user_id = (
+                  SELECT a2.user_id FROM agent a2 WHERE a2.id = :agentId LIMIT 1
+              )
+              OR
+              EXISTS (
+                  SELECT 1
+                  FROM agent_relation ar
+                  INNER JOIN agent_relation ar2
+                      ON ar2.object_id   = ar.agent_id
+                      AND ar2.object_type = 'MapasCulturais\\Entities\\Agent'
+                      AND ar2.agent_id   = :agentId
+                      AND ar2.status     IN (1, -5)
+                  WHERE ar.object_id   = r.id
+                    AND ar.object_type = '{$registrationObjectType}'
+                    AND ar.type        = 'coletivo'
+              )
+          )
+    ", [
+        'agentId'  => $agentId,
+        'oppId'    => $opportunityId,
+        'approved' => Registration::STATUS_APPROVED,
     ]);
-    $registrations = $query->find();
+
+    $registrations = [];
+ 
+    if (!empty($ids)) {
+        $query = new ApiQuery(Registration::class, [
+            '@select' => 'id,number,category,relatedAgents,owner.{name}',
+            '@order'  => 'id ASC',
+            'id'      => API::IN($ids),
+        ]);
+        $registrations = $query->find();
+    }
+ 
+    $app->enableAccessControl();
 
     $this->jsObject['config']['rcvRegistrationUpdate'] = [
         'registrations' => $registrations,


### PR DESCRIPTION
Substitui o filtro ApiQuery por user pelo owner para uma query SQL direta
que busca inscrições aprovadas considerando dois caminhos:
- Usuário é owner da inscrição
- Usuário tem relação com o agente coletivo (status 1 ou -5)

Permite que usuários convidados visualizem os pontos de cultura
independentemente de terem aceito ou não o convite.