### PR TITLE
Corretiva #9597 - Distribuição das Avaliações

### DIFF
--- a/EvaluationDistribution.php
+++ b/EvaluationDistribution.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace CulturaViva;
+
+use MapasCulturais\App;
+use MapasCulturais\Entities\Opportunity;
+use MapasCulturais\Entities\User;
+
+final class EvaluationDistribution
+{
+    public static function register(): void
+    {
+        $app = App::i();
+        $opportunity_ids = array_map('intval', [
+            $app->config['rcv.opportunityId'],
+            $app->config['rcv.pnabOpportunityId'],
+        ]);
+
+        $app->hook('evaluationMethod.distributionComparator', function (&$comparator, Opportunity $opportunity) use ($app, $opportunity_ids) {
+            $first_phase = $opportunity->firstPhase ?: $opportunity;
+            $evaluation_config = $opportunity->evaluationMethodConfiguration;
+            $ignore_started_evaluations = (array) ($evaluation_config->ignoreStartedEvaluations ?: []);
+
+            if (!self::supportsUniformDistribution(
+                $app->view instanceof Theme,
+                (int) $first_phase->id,
+                $opportunity_ids,
+                $ignore_started_evaluations
+            )) {
+                return;
+            }
+
+            $comparator = self::createComparator($ignore_started_evaluations);
+
+            $app->log->debug(sprintf(
+                'CulturaViva: distribuicao uniforme habilitada para a fase %d',
+                $opportunity->id
+            ));
+        });
+    }
+
+    public static function supportsUniformDistribution(
+        bool $is_cultura_viva,
+        int $first_phase_id,
+        array $opportunity_ids,
+        array $ignore_started_evaluations
+    ): bool {
+        return $is_cultura_viva
+            && in_array($first_phase_id, $opportunity_ids, true)
+            && (bool) array_filter($ignore_started_evaluations);
+    }
+
+    public static function createComparator(array $ignore_started_evaluations): callable
+    {
+        return function (
+            User $valuer1,
+            User $valuer2,
+            string $committee,
+            array $pending_assignments
+        ) use ($ignore_started_evaluations): ?int {
+            if (empty($ignore_started_evaluations[$committee])) {
+                return null;
+            }
+
+            return EvaluationDistribution::comparePendingAssignments(
+                $valuer1,
+                $valuer2,
+                $pending_assignments
+            );
+        };
+    }
+
+    public static function comparePendingAssignments(
+        User $valuer1,
+        User $valuer2,
+        array $pending_assignments
+    ): int {
+        $pending1 = $pending_assignments[$valuer1->id] ?? 0;
+        $pending2 = $pending_assignments[$valuer2->id] ?? 0;
+
+        if ($pending1 !== $pending2) {
+            return $pending1 <=> $pending2;
+        }
+
+        return $valuer1->id <=> $valuer2->id;
+    }
+}

--- a/Theme.php
+++ b/Theme.php
@@ -42,6 +42,7 @@ class Theme extends \MapasCulturais\Themes\BaseV2\Theme
         parent::_init();
 
         $app = App::i();
+        EvaluationDistribution::register();
 
         $self = $this;
 

--- a/tests/EvaluationDistributionTest.php
+++ b/tests/EvaluationDistributionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace CulturaViva\Tests;
+
+use CulturaViva\EvaluationDistribution;
+use MapasCulturais\Entities\User;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 4) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/EvaluationDistribution.php';
+
+class EvaluationDistributionTest extends TestCase
+{
+    function testOrdersByPendingAssignmentsBeforeUserId(): void
+    {
+        $valuer1 = new User();
+        $valuer1->id = 10;
+        $valuer2 = new User();
+        $valuer2->id = 20;
+        $pending_assignments = [10 => 2, 20 => 3];
+
+        $result = EvaluationDistribution::comparePendingAssignments(
+            $valuer1,
+            $valuer2,
+            $pending_assignments
+        );
+
+        $this->assertLessThan(0, $result);
+    }
+
+    function testUsesUserIdAsStableTiebreaker(): void
+    {
+        $valuer1 = new User();
+        $valuer1->id = 10;
+        $valuer2 = new User();
+        $valuer2->id = 20;
+
+        $by_user_id = EvaluationDistribution::comparePendingAssignments(
+            $valuer1,
+            $valuer2,
+            [10 => 2, 20 => 2]
+        );
+
+        $this->assertLessThan(0, $by_user_id);
+    }
+
+    function testOnlySupportsConfiguredCulturaVivaOpportunitiesWithAnEnabledCommittee(): void
+    {
+        $opportunity_ids = [5386, 5388];
+        $flags = ['committee 1' => true];
+
+        $this->assertTrue(EvaluationDistribution::supportsUniformDistribution(true, 5386, $opportunity_ids, $flags));
+        $this->assertFalse(EvaluationDistribution::supportsUniformDistribution(false, 5386, $opportunity_ids, $flags));
+        $this->assertFalse(EvaluationDistribution::supportsUniformDistribution(true, 9999, $opportunity_ids, $flags));
+        $this->assertFalse(EvaluationDistribution::supportsUniformDistribution(true, 5386, $opportunity_ids, ['committee 1' => false]));
+    }
+
+    function testComparatorDelegatesDisabledCommitteesToCore(): void
+    {
+        $comparator = EvaluationDistribution::createComparator([
+            'committee 1' => true,
+            'committee 2' => false,
+        ]);
+        $valuer1 = new User();
+        $valuer1->id = 10;
+        $valuer2 = new User();
+        $valuer2->id = 20;
+        $pending_assignments = [10 => 1, 20 => 2];
+
+        $this->assertLessThan(0, $comparator($valuer1, $valuer2, 'committee 1', $pending_assignments));
+        $this->assertNull($comparator($valuer1, $valuer2, 'committee 2', $pending_assignments));
+    }
+}


### PR DESCRIPTION
## Contexto

A distribuição atual considera o histórico acumulado dos avaliadores, o que pode concentrar novas pendências em uma única pessoa. Esse comportamento afeta especialmente oportunidades de fluxo contínuo, como as oportunidades principais do Cultura Viva.

## Alterações

* Adiciona uma estratégia de distribuição uniforme por comissão.
* Aplica a estratégia somente ao tema Cultura Viva.
* Restringe o comportamento às oportunidades configuradas em `rcv.opportunityId` e `rcv.pnabOpportunityId`.
* Utiliza a estratégia uniforme apenas nas comissões com a opção `ignoreStartedEvaluations` ativada.
* Mantém o comparador padrão do core quando a opção está desativada.
* Utiliza o ID do usuário como critério de desempate determinístico.
* Adiciona testes unitários para validar o escopo, a flag, o balanceamento e o fallback.

## Comportamento

Com a opção ativada, o histórico de avaliações iniciadas, concluídas e enviadas é preservado, mas deixa de influenciar a atribuição das pendências.

Filtros, limites individuais, listas, inclusões, exclusões, quantidade de avaliadores por inscrição e voto de minerva continuam sendo processados pelo core.

## Dependências

Este PR depende do ponto de extensão `evaluationMethod.distributionComparator` no core.

A mitigação de cotas automáticas do plugin RCV deve permanecer removida para evitar estratégias concorrentes.

Os valores de `maxRegistrations` persistidos anteriormente também precisam ser revisados ou removidos da oportunidade `5386`.
